### PR TITLE
Check short term memory and fifo queue

### DIFF
--- a/memoryos-mcp/config.json
+++ b/memoryos-mcp/config.json
@@ -4,7 +4,7 @@
   "openai_base_url": "",
   "data_storage_path": "./memoryos_data",
   "assistant_id": "memoryos_assistant",
-  "short_term_capacity": 2,
+  "short_term_capacity": 10,
   "mid_term_capacity": 2000,
   "embedding_model_name": "all-MiniLM-L6-v2",
   "long_term_knowledge_capacity": 100,


### PR DESCRIPTION
Increase short-term memory capacity to 10 to provide more context and reduce processing frequency.

This change was requested by the user to allow the system to hold more recent QA pairs in short-term memory, improving immediate retrieval and reducing the need for frequent processing to mid-term storage.

---
<a href="https://cursor.com/background-agent?bcId=bc-af51795a-be16-4708-a54f-4668e86b82b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-af51795a-be16-4708-a54f-4668e86b82b1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

