### PR TITLE
Fix deployment import error

### DIFF
--- a/memoryos-mcp/memoryos/long_term.py
+++ b/memoryos-mcp/memoryos/long_term.py
@@ -2,10 +2,7 @@ import json
 import numpy as np
 import faiss
 from collections import deque
-try:
-    from .utils import get_timestamp, get_embedding, normalize_vector, ensure_directory_exists
-except ImportError:
-    from utils import get_timestamp, get_embedding, normalize_vector, ensure_directory_exists
+from .utils import get_timestamp, get_embedding, normalize_vector, ensure_directory_exists
 
 class LongTermMemory:
     def __init__(self, file_path, knowledge_capacity=100, embedding_model_name: str = "all-MiniLM-L6-v2", embedding_model_kwargs: dict = None):

--- a/memoryos-mcp/memoryos/memoryos.py
+++ b/memoryos-mcp/memoryos/memoryos.py
@@ -2,25 +2,14 @@ import os
 import json
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-# 修改为绝对导入
-try:
-    # 尝试相对导入（当作为包使用时）
-    from .utils import OpenAIClient, get_timestamp, generate_id, gpt_user_profile_analysis, gpt_knowledge_extraction, ensure_directory_exists
-    from . import prompts
-    from .short_term import ShortTermMemory
-    from .mid_term import MidTermMemory, compute_segment_heat # For H_THRESHOLD logic
-    from .long_term import LongTermMemory
-    from .updater import Updater
-    from .retriever import Retriever
-except ImportError:
-    # 回退到绝对导入（当作为独立模块使用时）
-    from utils import OpenAIClient, get_timestamp, generate_id, gpt_user_profile_analysis, gpt_knowledge_extraction, ensure_directory_exists
-    import prompts
-    from short_term import ShortTermMemory
-    from mid_term import MidTermMemory, compute_segment_heat # For H_THRESHOLD logic
-    from long_term import LongTermMemory
-    from updater import Updater
-    from retriever import Retriever
+# Package imports
+from .utils import OpenAIClient, get_timestamp, generate_id, gpt_user_profile_analysis, gpt_knowledge_extraction, ensure_directory_exists
+from . import prompts
+from .short_term import ShortTermMemory
+from .mid_term import MidTermMemory, compute_segment_heat # For H_THRESHOLD logic
+from .long_term import LongTermMemory
+from .updater import Updater
+from .retriever import Retriever
 
 # Heat threshold for triggering profile/knowledge update from mid-term memory
 H_PROFILE_UPDATE_THRESHOLD = 5.0 

--- a/memoryos-mcp/memoryos/mid_term.py
+++ b/memoryos-mcp/memoryos/mid_term.py
@@ -5,16 +5,10 @@ import faiss
 import heapq
 from datetime import datetime
 
-try:
-    from .utils import (
-        get_timestamp, generate_id, get_embedding, normalize_vector, 
-        compute_time_decay, ensure_directory_exists, OpenAIClient
-    )
-except ImportError:
-    from utils import (
-        get_timestamp, generate_id, get_embedding, normalize_vector, 
-        compute_time_decay, ensure_directory_exists, OpenAIClient
-    )
+from .utils import (
+    get_timestamp, generate_id, get_embedding, normalize_vector, 
+    compute_time_decay, ensure_directory_exists, OpenAIClient
+)
 
 # Heat computation constants (can be tuned or made configurable)
 HEAT_ALPHA = 1.0

--- a/memoryos-mcp/memoryos/retriever.py
+++ b/memoryos-mcp/memoryos/retriever.py
@@ -3,16 +3,10 @@ import heapq
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Optional
 
-try:
-    from .utils import get_timestamp, OpenAIClient, run_parallel_tasks
-    from .short_term import ShortTermMemory
-    from .mid_term import MidTermMemory
-    from .long_term import LongTermMemory
-except ImportError:
-    from utils import get_timestamp, OpenAIClient, run_parallel_tasks
-    from short_term import ShortTermMemory
-    from mid_term import MidTermMemory
-    from long_term import LongTermMemory
+from .utils import get_timestamp, OpenAIClient, run_parallel_tasks
+from .short_term import ShortTermMemory
+from .mid_term import MidTermMemory
+from .long_term import LongTermMemory
 # from .updater import Updater # Updater is not directly used by Retriever
 
 class Retriever:

--- a/memoryos-mcp/memoryos/short_term.py
+++ b/memoryos-mcp/memoryos/short_term.py
@@ -1,9 +1,6 @@
 import json
 from collections import deque
-try:
-    from .utils import get_timestamp, ensure_directory_exists
-except ImportError:
-    from utils import get_timestamp, ensure_directory_exists
+from .utils import get_timestamp, ensure_directory_exists
 
 class ShortTermMemory:
     def __init__(self, file_path, max_capacity=10):

--- a/memoryos-mcp/memoryos/updater.py
+++ b/memoryos-mcp/memoryos/updater.py
@@ -1,21 +1,11 @@
-try:
-    from .utils import (
-        generate_id, get_timestamp, 
-        gpt_generate_multi_summary, check_conversation_continuity, generate_page_meta_info, OpenAIClient,
-        run_parallel_tasks
-    )
-    from .short_term import ShortTermMemory
-    from .mid_term import MidTermMemory
-    from .long_term import LongTermMemory
-except ImportError:
-    from utils import (
-        generate_id, get_timestamp, 
-        gpt_generate_multi_summary, check_conversation_continuity, generate_page_meta_info, OpenAIClient,
-        run_parallel_tasks
-    )
-    from short_term import ShortTermMemory
-    from mid_term import MidTermMemory
-    from long_term import LongTermMemory
+from .utils import (
+    generate_id, get_timestamp, 
+    gpt_generate_multi_summary, check_conversation_continuity, generate_page_meta_info, OpenAIClient,
+    run_parallel_tasks
+)
+from .short_term import ShortTermMemory
+from .mid_term import MidTermMemory
+from .long_term import LongTermMemory
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 

--- a/memoryos-mcp/memoryos/utils.py
+++ b/memoryos-mcp/memoryos/utils.py
@@ -7,10 +7,7 @@ import json
 import os
 import inspect
 from functools import wraps
-try:
-    from . import prompts # 尝试相对导入
-except ImportError:
-    import prompts # 回退到绝对导入
+from . import prompts
 from openai import OpenAI
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import threading

--- a/memoryos-mcp/server_new.py
+++ b/memoryos-mcp/server_new.py
@@ -5,8 +5,6 @@ import json
 import argparse
 from typing import Any, Dict, Optional, List
 from dotenv import load_dotenv
-# Ensure the current directory is in sys.path so that the `memoryos` package can be imported
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'memoryos'))
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -16,8 +14,8 @@ except ImportError as e:
     sys.exit(1)
 
 try:
-    from memoryos import Memoryos
-    from utils import get_timestamp
+    from memoryos.memoryos import Memoryos
+    from memoryos.utils import get_timestamp
 except ImportError as e:
     print(f"无法导入MemoryOS模块: {e}", file=sys.stderr)
     print("请确保项目结构正确，memoryos目录应包含所有必要文件", file=sys.stderr)


### PR DESCRIPTION
Fixes `ImportError: attempted relative import with no known parent package` by standardizing Python package imports.

The deployment environment caused `ImportError` because `server_new.py` was incorrectly manipulating `sys.path` and other modules used inconsistent try/except blocks for imports. This PR removes the problematic `sys.path` modification and ensures all internal package imports are consistently relative, allowing the `memoryos` package to be imported correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-16680d5f-f213-47fe-8b2b-0c7058ab18a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-16680d5f-f213-47fe-8b2b-0c7058ab18a7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

