### PR TITLE
Fix relative import error in server deployment

### DIFF
--- a/memoryos-mcp/server_new.py
+++ b/memoryos-mcp/server_new.py
@@ -6,7 +6,7 @@ import argparse
 from typing import Any, Dict, Optional, List
 from dotenv import load_dotenv
 # Ensure the current directory is in sys.path so that the `memoryos` package can be imported
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'memoryos'))
+sys.path.insert(0, os.path.dirname(__file__))
 
 try:
     from mcp.server.fastmcp import FastMCP
@@ -17,7 +17,7 @@ except ImportError as e:
 
 try:
     from memoryos import Memoryos
-    from utils import get_timestamp
+    from memoryos.utils import get_timestamp
 except ImportError as e:
     print(f"无法导入MemoryOS模块: {e}", file=sys.stderr)
     print("请确保项目结构正确，memoryos目录应包含所有必要文件", file=sys.stderr)


### PR DESCRIPTION
Fixes deployment failure due to Python import errors by correcting `sys.path` and module imports.

The original `server_new.py` incorrectly added the `memoryos` subdirectory to `sys.path`, causing Python to treat `memoryos` as a top-level module instead of a package when `server_new.py` was run directly. This broke relative imports within the `memoryos` package. The fix adjusts `sys.path` to include the parent directory and explicitly imports `memoryos.utils`, resolving the `ImportError`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9a5d0611-3219-4558-91e3-acf2cacda060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9a5d0611-3219-4558-91e3-acf2cacda060">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

